### PR TITLE
Improve deploy instructions for Part A

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -3,7 +3,7 @@
 [Istio](http://istio.io) is an open platform that provides a uniform way to connect, manage, and secure microservices. Istio is the result of a joint collaboration between IBM, Google and Lyft as a means to support traffic flow management, access policy enforcement and the telemetry data aggregation between microservices, all without requiring changes to the code of your microservice. Istio provides an easy way to create this service mesh by deploying a [control plane](https://istio.io/docs/concepts/what-is-istio/overview.html#architecture) and injecting sidecars, an extended version of the  [Envoy](https://lyft.github.io/envoy/) proxy, in the same Pod as your microservice.
 
 # Prerequisite
-Create a Kubernetes cluster with either [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube) for local testing, or with [IBM Bluemix Container Service](https://github.com/IBM/container-journey-template/blob/master/README.md) to deploy in cloud. 
+Create a Kubernetes cluster with either [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube) for local testing, or with [IBM Bluemix Container Service](https://github.com/IBM/container-journey-template/blob/master/README.md) to deploy in cloud.
 
 # Steps
 
@@ -12,12 +12,20 @@ Create a Kubernetes cluster with either [Minikube](https://kubernetes.io/docs/ge
 ## 1. Install Istio on Kubernetes
 
 ### 1.1 Download the Istio source
-  1. Download the latest Istio release for your OS: [Istio releases](https://github.com/istio/istio/releases)  
-  2. Extract and go to the root directory.
-  3. Copy the `istioctl` bin to your local bin  
+
+  > Note: This example is tested with istio 1.6, we recommend you use this version for consistency.
+    Ensure you extract the files to the specified location so that the commands in the instructions
+    work for you.
+
+  1. Download Istio release for your OS: [Istio releases](https://github.com/istio/istio/releases)  
+  2. Extract the tarball into the `ibm` directory we created earlier.
+  3. Copy the `istioctl` bin to somewhere in your executable path
+
   ```bash
-  $ cp bin/istioctl /usr/local/bin
-  ## example for macOS
+  $ tar xzvf <path-to-istio-download>
+  $ mv istio-<VERSION> istio
+  $ cp istio/bin/istioctl /usr/local/bin
+
   ```
 
 ### 1.2 Grant Permissions  

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ $ echo $URL
 http://184.xxx.yyy.zzz:30XYZ
 ```
 
-At this point, you can point your browser to the provided URL or run `$ firefox $URL/productpage` and see the BookInfo Application.
+At this point, you can point your browser to the provided URL (or run `$ firefox $GRAFANA/dashboard/db/istio-dashboard` if you have firefox installed) and see the BookInfo Application.
 
 The next step would be deploying this sample application with Istio Envoys injected. You should now delete the sample application to proceed to the next step. This is needed at this point because currently Istio doesn't dupport injecting Envoy proxies in an already deployed application, though that's a feature which is in plan.
 
@@ -250,7 +250,7 @@ This step shows you how to configure [Istio Mixer](https://istio.io/docs/concept
   $ echo $GRAFANA
   184.xxx.yyy.zzz:30XYZ
   ```
-  Point your browser to http://184.xxx.yyy.zzz:30XYZ/dashboard/db/istio-dashboard. `$ firefox $GRAFANA/dashboard/db/istio-dashboard` to go directly to your dashboard.  
+  Point your browser to http://184.xxx.yyy.zzz:30XYZ/dashboard/db/istio-dashboard (or run `$ firefox $GRAFANA/dashboard/db/istio-dashboard` if you have firefox installed) to go directly to your dashboard.  
 
   Your dashboard should look like this:  
   ![Grafana-Dashboard](images/grafana.png)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/IBM/Microservices-with-Istio-Service-Mesh-on-Kubernetes.svg?branch=master)](https://travis-ci.org/IBM/Microservices-with-Istio-Service-Mesh-on-Kubernetes)
+[![Build Status](https://travis-ci.org/IBM/traffic-management-for-your-microservices-using-istio.svg?branch=master)](https://travis-ci.org/IBM/traffic-management-for-your-microservices-using-istio)
 
 # Istio: Traffic Management for your Microservices
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ other Operating Systems._
 
 ```bash
 $ curl -SL https://github.com/istio/istio/releases/download/0.1.6/istio-0.1.6-linux.tar.gz | tar xzf -
-$ sudo cp istio-0.1.6/bin/istioctl /usr/local/bin/
-$ kubectl apply -f istio-0.1.6/install/kubernetes/istio-rbac-beta.yaml
-$ kubectl apply -f istio-0.1.6/install/kubernetes/istio.yaml
+$ mv istio-0.1.6 istio
+$ sudo cp istio/bin/istioctl /usr/local/bin/
+$ kubectl apply -f istio/install/kubernetes/istio-rbac-beta.yaml
+$ kubectl apply -f istio/install/kubernetes/istio.yaml
 
 ```
 
@@ -93,7 +94,7 @@ In this part, we will be using the sample BookInfo Application that comes as def
 * Deploy the BookInfo Application in your Cluster
 
 ```bash
-$ kubectl apply -f istio-0.1.6/samples/apps/bookinfo/bookinfo.yaml
+$ kubectl apply -f istio/samples/apps/bookinfo/bookinfo.yaml
 ```
 
 * If are using minikube or you don't have access to external load balancers, you need to use NodePort on the `productpage` service. Run the following command to use a NodePort:
@@ -115,7 +116,7 @@ At this point, you can point your browser to the provided URL (or run `$ firefox
 The next step would be deploying this sample application with Istio Envoys injected. You should now delete the sample application to proceed to the next step. This is needed at this point because currently Istio doesn't dupport injecting Envoy proxies in an already deployed application, though that's a feature which is in plan.
 
 ```bash
-$ kubectl delete -f istio-0.1.6/samples/apps/bookinfo/bookinfo.yaml
+$ kubectl delete -f istio/samples/apps/bookinfo/bookinfo.yaml
 ```
 
 ## 2. Inject Istio envoys on the application
@@ -125,7 +126,7 @@ $ kubectl delete -f istio-0.1.6/samples/apps/bookinfo/bookinfo.yaml
 Envoys are deployed as sidecars on each microservice. Injecting Envoy into your microservice means that the Envoy sidecar would manage the ingoing and outgoing calls for the service. To inject an Envoy sidecar to an existing microservice configuration, do:
 
 ```bash
-$ kubectl apply -f <(istioctl kube-inject -f istio-0.1.6/samples/apps/bookinfo/bookinfo.yaml)
+$ kubectl apply -f <(istioctl kube-inject -f istio/samples/apps/bookinfo/bookinfo.yaml)
 ```
 
 > `istioctl kube-inject` modifies the yaml file passed in _-f_. This injects Envoy sidecar into your Kubernetes resource configuration. The only resources updated are Job, DaemonSet, ReplicaSet, and Deployment. Other resources in the YAML file configuration will be left unmodified.
@@ -176,7 +177,7 @@ This step shows you how to configure where you want your service requests to go 
 This would set all incoming routes on the services (indicated in the line `destination: <service>`) to the deployment with a tag `version: v1`. To set the default routes, run:
 
   ```bash
-  $ istioctl create -f istio-0.1.6/samples/apps/bookinfo/route-rule-all-v1.yaml
+  $ istioctl create -f istio/samples/apps/bookinfo/route-rule-all-v1.yaml
   ```
 
 * Set Route to `reviews-v2` of **reviews microservice** for a specific user  
@@ -184,7 +185,7 @@ This would set all incoming routes on the services (indicated in the line `desti
 This would set the route for the user `jason` (You can login as _jason_ with any password in your deploy web application) to see the `version: v2` of the reviews microservice. Run:
 
   ```bash
-  $ istioctl create -f istio-0.1.6/samples/apps/bookinfo/route-rule-reviews-test-v2.yaml
+  $ istioctl create -f istio/samples/apps/bookinfo/route-rule-reviews-test-v2.yaml
   ```
 
 * Route 50% of traffic on **reviews microservice** to `reviews-v1` and 50% to `reviews-v3`.  
@@ -194,7 +195,7 @@ This is indicated by the `weight: 50` in the yaml file.
   > Using `replace` should allow you to edit exisiting route-rules.
 
   ```bash
-  $ istioctl replace -f istio-0.1.6/samples/apps/bookinfo/route-rule-reviews-50-v3.yaml
+  $ istioctl replace -f istio/samples/apps/bookinfo/route-rule-reviews-50-v3.yaml
 
   ```
 
@@ -203,7 +204,7 @@ This is indicated by the `weight: 50` in the yaml file.
 This would set every incoming traffic to the version v3 of the reviews microservice. Run:
 
   ```bash
-  $ istioctl replace -f istio-0.1.6/samples/apps/bookinfo/route-rule-reviews-v3.yaml
+  $ istioctl replace -f istio/samples/apps/bookinfo/route-rule-reviews-v3.yaml
   ```
 
 ## 4. Access policy enforcement using Istio Auth - Configure access control
@@ -213,7 +214,7 @@ This step shows you how to control access to your services. If you have done the
 * To deny access to the ratings service from the traffic coming from `reviews-v3`, you will use `istioctl mixer rule create`
 
   ```bash
-  $ istioctl mixer rule create global ratings.default.svc.cluster.local -f istio-0.1.6/samples/apps/bookinfo/mixer-rule-ratings-denial.yaml
+  $ istioctl mixer rule create global ratings.default.svc.cluster.local -f istio/samples/apps/bookinfo/mixer-rule-ratings-denial.yaml
   ```
 
   The `mixer-rule-ratings-denial.yaml` file creates a rule that denies `kind: denials` access from reviews service and has a label of v3 `selector: source.labels["app"]=="reviews" && source.labels["version"] == "v3"`  
@@ -240,8 +241,8 @@ This step shows you how to configure [Istio Mixer](https://istio.io/docs/concept
 
 * Install the required Istio Addons on your cluster: [Prometheus](https://prometheus.io) and [Grafana](https://grafana.com)
   ```bash
-  $ kubectl apply -f istio-0.1.6/install/kubernetes/addons/prometheus.yaml
-  $ kubectl apply -f istio-0.1.6/install/kubernetes/addons/grafana.yaml
+  $ kubectl apply -f istio/install/kubernetes/addons/prometheus.yaml
+  $ kubectl apply -f istio/install/kubernetes/addons/grafana.yaml
   ```
 * Verify that your **Grafana** dashboard is ready. Get the IP of your cluster `kubectl get nodes` and then the NodePort of your Grafana service `kubectl get svc | grep grafana` or you can run the following command to output both:
 
@@ -297,7 +298,7 @@ This step shows you how to collect trace spans using [Zipkin](http://zipkin.io).
 * Install the required Istio Addon: [Zipkin](http://zipkin.io)
 
   ```bash
-  $ kubectl apply -f istio-0.1.6/install/kubernetes/addons/zipkin.yaml
+  $ kubectl apply -f istio/install/kubernetes/addons/zipkin.yaml
   ```
 
 * Access your **Zipkin Dashboard**. Get the IP of your cluster `kubectl get nodes` and then the NodePort of your Zipkin service `kubectl get svc | grep zipkin` or you can run the following command to output both:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,26 @@ In the [second part](#part-b-modify-sample-application-to-use-an-external-dataso
 # Prerequisite
 Create a Kubernetes cluster with either [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube) for local testing, or with [IBM Bluemix Container Service](https://github.com/IBM/container-journey-template/blob/master/README.md) to deploy in cloud. The code here is regularly tested against [Kubernetes Cluster from Bluemix Container Service](https://console.ng.bluemix.net/docs/containers/cs_ov.html#cs_ov) using Travis.
 
-You will also need Istio service mesh installed on top of your Kubernetes cluster. Please follow the instructions [here](https://github.com/IBM/Microservices-with-Istio-Service-Mesh-on-Kubernetes/blob/master/GETTING_STARTED.md) to get Istio mesh installed on Kubernetes.
+Create a working directory to clone this repo and to download Istio into:
+
+```bash
+$ mkdir ibm
+$ cd ibm
+$ git clone https://github.com/IBM/Traffic-management-for-your-microservices-using-Istio.git demo
+```
+
+You will also need Istio service mesh installed on top of your Kubernetes cluster. On Linux (with kubernetes that has beta RBAC) you can run the following:
+
+_See [here](https://github.com/IBM/Microservices-with-Istio-Service-Mesh-on-Kubernetes/blob/master/GETTING_STARTED.md) for troubleshooting, more detailed instructions, and for
+other Operating Systems._
+
+```bash
+$ curl -SL https://github.com/istio/istio/releases/download/0.1.6/istio-0.1.6-linux.tar.gz | tar xzf -
+$ sudo cp istio-0.1.6/bin/istioctl /usr/local/bin/
+$ kubectl apply -f istio-0.1.6/install/kubernetes/istio-rbac-beta.yaml
+$ kubectl apply -f istio-0.1.6/install/kubernetes/istio.yaml
+
+```
 
 # Deploy to Bluemix
 If you want to deploy the BookInfo app directly to Bluemix, click on 'Deploy to Bluemix' button below to create a Bluemix DevOps service toolchain and pipeline for deploying the sample, else jump to [Steps](#steps)
@@ -72,45 +91,43 @@ Please follow the [Toolchain instructions](https://github.com/IBM/container-jour
 In this part, we will be using the sample BookInfo Application that comes as default with Istio code base. As mentioned above, the application that is composed of four microservices, written in different languages for each of its microservices namely Python, Java, Ruby, and Node.js. The default application doesn't use a database and all the microservices store their data in the local file system.
 
 * Deploy the BookInfo Application in your Cluster
+
 ```bash
-$ kubectl apply -f samples/apps/bookinfo/bookinfo.yaml
+$ kubectl apply -f istio-0.1.6/samples/apps/bookinfo/bookinfo.yaml
 ```
-* If you don't have access to external load balancers, you need to use NodePort on the `productpage` service. Run the following command to use a NodePort:
-```yaml
-cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: Service
-metadata:
-  name: productpage
-  labels:
-    app: productpage
-spec:
-  type: NodePort
-  ports:
-  - port: 9080
-    name: http
-  selector:
-    app: productpage
-EOF
-```
-* To show your cluster’s IP address and NotePort of your `productpage` service use: _(If you have a load balancer, you can access it through the IP found on `kubectl get ingress`)_
+
+* If are using minikube or you don't have access to external load balancers, you need to use NodePort on the `productpage` service. Run the following command to use a NodePort:
+
 ```bash
-$ echo $(kubectl get po -l app=productpage -o jsonpath={.items[0].status.hostIP}):$(kubectl get svc productpage -o jsonpath={.spec.ports[0].nodePort})
-184.xxx.yyy.zzz:30XYZ
+$ kubectl apply -f demo/node-port.yaml
 ```
-At this point, you can point your browser to http://184.xxx.yyy.zzz:30XYZ/productpage and see the BookInfo Application.
+
+* If you have a load balancer, you find the URL through the IP found on `kubectl get ingress` and skip this step.  Otherwise to show your cluster’s IP address and NotePort of your `productpage` run:
+
+```bash
+$ export URL=http://$(kubectl get po -l app=productpage -o jsonpath='{.items[0].status.hostIP}'):$(kubectl get svc productpage -o jsonpath='{.spec.ports[0].nodePort}')
+$ echo $URL
+http://184.xxx.yyy.zzz:30XYZ
+```
+
+At this point, you can point your browser to the provided URL or run `$ firefox $URL/productpage` and see the BookInfo Application.
 
 The next step would be deploying this sample application with Istio Envoys injected. You should now delete the sample application to proceed to the next step. This is needed at this point because currently Istio doesn't dupport injecting Envoy proxies in an already deployed application, though that's a feature which is in plan.
+
 ```bash
-$ kubectl delete -f samples/apps/bookinfo/bookinfo.yaml
+$ kubectl delete -f istio-0.1.6/samples/apps/bookinfo/bookinfo.yaml
 ```
 
 ## 2. Inject Istio envoys on the application
 
+> Note: If you did not delete the app from stage 1 you will see issues if you proceed with this stage._
+
 Envoys are deployed as sidecars on each microservice. Injecting Envoy into your microservice means that the Envoy sidecar would manage the ingoing and outgoing calls for the service. To inject an Envoy sidecar to an existing microservice configuration, do:
+
 ```bash
-$ kubectl apply -f <(istioctl kube-inject -f samples/apps/bookinfo/bookinfo.yaml)
+$ kubectl apply -f <(istioctl kube-inject -f istio-0.1.6/samples/apps/bookinfo/bookinfo.yaml)
 ```
+
 > `istioctl kube-inject` modifies the yaml file passed in _-f_. This injects Envoy sidecar into your Kubernetes resource configuration. The only resources updated are Job, DaemonSet, ReplicaSet, and Deployment. Other resources in the YAML file configuration will be left unmodified.
 
 After a few minutes, you should now have your Kubernetes Pods running and have an Envoy sidecar in each of them alongside the microservice. The microservices are **productpage, details, ratings, and reviews**. Note that you'll have three versions of the reviews microservice.
@@ -130,10 +147,13 @@ reviews-v2-2593570575-92657       2/2       Running   0
 reviews-v3-3121725201-cn371       2/2       Running   0       
 ```
 To access your application, you can check the public IP address of your cluster through `kubectl get nodes` and get the NodePort of the istio-ingress service for port 80 through `kubectl get svc | grep istio-ingress`. Or you can also run the following command to output the IP address and NodePort:
+
 ```bash
-echo $(kubectl get po -l istio=ingress -o jsonpath={.items[0].status.hostIP}):$(kubectl get svc istio-ingress -o jsonpath={.spec.ports[0].nodePort})
+$ export URL=http://$(kubectl get po -l istio=ingress -o jsonpath='{.items[0].status.hostIP}'):$(kubectl get svc istio-ingress -o jsonpath='{.spec.ports[0].nodePort}')
+$ echo $URL
 184.xxx.yyy.zzz:30XYZ
 ```
+
 Point your browser to:  
 `http://184.xxx.yyy.zzz:30XYZ/productpage` Replace with your own IP and NodePort.
 
@@ -152,25 +172,38 @@ There are multiple ways in which we can control this routing. It can be based on
 This step shows you how to configure where you want your service requests to go based on weights and HTTP Headers.You would need to be in the root directory of the Istio release you have downloaded on the Prerequisites section.
 
 * Set Default Routes to `reviews-v1` for all microservices  
+
 This would set all incoming routes on the services (indicated in the line `destination: <service>`) to the deployment with a tag `version: v1`. To set the default routes, run:
+
   ```bash
-  $ istioctl create -f samples/apps/bookinfo/route-rule-all-v1.yaml
+  $ istioctl create -f istio-0.1.6/samples/apps/bookinfo/route-rule-all-v1.yaml
   ```
+
 * Set Route to `reviews-v2` of **reviews microservice** for a specific user  
+
 This would set the route for the user `jason` (You can login as _jason_ with any password in your deploy web application) to see the `version: v2` of the reviews microservice. Run:
+
   ```bash
-  $ istioctl create -f samples/apps/bookinfo/route-rule-reviews-test-v2.yaml
+  $ istioctl create -f istio-0.1.6/samples/apps/bookinfo/route-rule-reviews-test-v2.yaml
   ```
+
 * Route 50% of traffic on **reviews microservice** to `reviews-v1` and 50% to `reviews-v3`.  
+
 This is indicated by the `weight: 50` in the yaml file.
+
+  > Using `replace` should allow you to edit exisiting route-rules.
+
   ```bash
-  $ istioctl replace -f samples/apps/bookinfo/route-rule-reviews-50-v3.yaml
-  # using `replace` should allow you to edit exisiting route-rules.
+  $ istioctl replace -f istio-0.1.6/samples/apps/bookinfo/route-rule-reviews-50-v3.yaml
+
   ```
+
 * Route 100% of the traffic to the `version: v3` of the **reviews microservices**  
+
 This would set every incoming traffic to the version v3 of the reviews microservice. Run:
+
   ```bash
-  $ istioctl replace -f samples/apps/bookinfo/route-rule-reviews-v3.yaml
+  $ istioctl replace -f istio-0.1.6/samples/apps/bookinfo/route-rule-reviews-v3.yaml
   ```
 
 ## 4. Access policy enforcement using Istio Auth - Configure access control
@@ -178,19 +211,24 @@ This would set every incoming traffic to the version v3 of the reviews microserv
 This step shows you how to control access to your services. If you have done the step above, you'll see that your `productpage` now just shows red stars on the reviews section and if you are logged in as _jason_, you'll see black stars. The `ratings` service is accessed from the `reviews-v2` if you're logged in as _jason_ or it is accessed from `reviews-v3` if you are not logged in as `jason`.
 
 * To deny access to the ratings service from the traffic coming from `reviews-v3`, you will use `istioctl mixer rule create`
+
   ```bash
-  $ istioctl mixer rule create global ratings.default.svc.cluster.local -f samples/apps/bookinfo/mixer-rule-ratings-denial.yaml
+  $ istioctl mixer rule create global ratings.default.svc.cluster.local -f istio-0.1.6/samples/apps/bookinfo/mixer-rule-ratings-denial.yaml
   ```
+
   The `mixer-rule-ratings-denial.yaml` file creates a rule that denies `kind: denials` access from reviews service and has a label of v3 `selector: source.labels["app"]=="reviews" && source.labels["version"] == "v3"`  
   You can verify using `istioctl mixer rule get global ratings.default.svc.cluster.local` if the mixer rule has been created that way:
-  ```yaml
+
+  ```bash
   $ istioctl mixer rule get global ratings.default.svc.cluster.local
   rules:
   - aspects:
     - kind: denials
     selector: source.labels["app"]=="reviews" && source.labels["version"] == "v3"
   ```
+
 * To verify if your rule has been enforced, point your browser to your BookInfo Application, you wouldn't see star ratings anymore from the reviews section unless you are logged in as _jason_ which you will still see black stars (because you would be using the reviews-v2 as you have done in [Step 4](#4-modify-service-routes)).
+
 ![access-control](images/access.png)
 
 
@@ -202,82 +240,49 @@ This step shows you how to configure [Istio Mixer](https://istio.io/docs/concept
 
 * Install the required Istio Addons on your cluster: [Prometheus](https://prometheus.io) and [Grafana](https://grafana.com)
   ```bash
-  $ kubectl apply -f install/kubernetes/addons/prometheus.yaml
-  $ kubectl apply -f install/kubernetes/addons/grafana.yaml
+  $ kubectl apply -f istio-0.1.6/install/kubernetes/addons/prometheus.yaml
+  $ kubectl apply -f istio-0.1.6/install/kubernetes/addons/grafana.yaml
   ```
 * Verify that your **Grafana** dashboard is ready. Get the IP of your cluster `kubectl get nodes` and then the NodePort of your Grafana service `kubectl get svc | grep grafana` or you can run the following command to output both:
+
   ```bash
-  $ echo $(kubectl get po -l app=grafana -o jsonpath={.items[0].status.hostIP}):$(kubectl get svc grafana -o jsonpath={.spec.ports[0].nodePort})
+  $ export GRAFANA=http://$(kubectl get po -l app=grafana -o jsonpath='{.items[0].status.hostIP}'):$(kubectl get svc grafana -o jsonpath='{.spec.ports[0].nodePort}')
+  $ echo $GRAFANA
   184.xxx.yyy.zzz:30XYZ
   ```
-  Point your browser to `184.xxx.yyy.zzz:30XYZ/dashboard/db/istio-dashboard` to go directly to your dashboard.  
+  Point your browser to http://184.xxx.yyy.zzz:30XYZ/dashboard/db/istio-dashboard. `$ firefox $GRAFANA/dashboard/db/istio-dashboard` to go directly to your dashboard.  
+
   Your dashboard should look like this:  
   ![Grafana-Dashboard](images/grafana.png)
 
 * To collect new telemetry data, you will use `istio mixer rule create`. For this sample, you will generate logs for Response Size for Reviews service. The configuration YAML file is provided within the BookInfo sample folder. Validate that your Reviews service has no service-specific rules already applied.
+
   ```bash
   $ istioctl mixer rule get reviews.default.svc.cluster.local reviews.default.svc.cluster.local
   Error: the server could not find the requested resource
   ```
-* Create a configuration YAML file and name it as `new_rule.yaml`:
-  ```yaml
-  revision: "1"
-  rules:
-  - aspects:
-    - adapter: prometheus
-      kind: metrics
-      params:
-        metrics:
-        - descriptor_name: response_size
-          value: response.size | 0
-          labels:
-            source: source.labels["app"] | "unknown"
-            target: target.service | "unknown"
-            service: target.labels["app"] | "unknown"
-            version: target.labels["version"] | "unknown"
-            method: request.path | "unknown"
-            response_code: response.code | 200
-    - adapter: default
-      kind: access-logs
-      params:
-        logName: combined_log
-        log:
-          descriptor_name: accesslog.combined
-          template_expressions:
-            originIp: origin.ip
-            sourceUser: origin.user
-            timestamp: request.time
-            method: request.method
-            url: request.path
-            protocol: request.scheme
-            responseCode: response.code
-            responseSize: response.size
-            referer: request.referer
-            userAgent: request.headers["user-agent"]
-          labels:
-            originIp: origin.ip
-            sourceUser: origin.user
-            timestamp: request.time
-            method: request.method
-            url: request.path
-            protocol: request.scheme
-            responseCode: response.code
-            responseSize: response.size
-            referer: request.referer
-            userAgent: request.headers["user-agent"]
-  ```
-* Create the configuration on Istio Mixer.
+
+* Create the configuration on Istio Mixer using the configuration in [new-metrics-rule.yaml](new-metrics-rule.yaml)
+`
   ```bash
-  istioctl mixer rule create reviews.default.svc.cluster.local reviews.default.svc.cluster.local -f new_rule.yaml
+  $ istioctl mixer rule create reviews.default.svc.cluster.local reviews.default.svc.cluster.local -f demo/new-metrics-rule.yaml
   ```
+
 * Send traffic to that service by refreshing your browser to `http://184.xxx.yyy.zzz:30XYZ/productpage` multiple times. You can also do `curl` on your terminal to that URL in a while loop.
 
+  ```bash
+  $ for i in {1..5}; do echo -n .; curl -s $URL/productpage > /dev/null; done
+  ```
+
 * Verify that the new metric is being collected by going to your Grafana dashboard again. The graph on the rightmost should now be populated.
+
 ![grafana-new-metric](images/grafana-new-metric.png)
 
 * Verify that the logs stream has been created and is being populated for requests
+
   ```bash
   $ kubectl logs $(kubectl get pods -l istio=mixer -o jsonpath='{.items[0].metadata.name}') | grep \"combined_log\"
+
   {"logName":"combined_log","labels":{"referer":"","responseSize":871,"timestamp":"2017-04-29T02:11:54.989466058Z","url":"/reviews","userAgent":"python-requests/2.11.1"},"textPayload":"- - - [29/Apr/2017:02:11:54 +0000] \"- /reviews -\" - 871 - python-requests/2.11.1"}
   ...
   ...
@@ -290,22 +295,28 @@ This step shows you how to configure [Istio Mixer](https://istio.io/docs/concept
 
 This step shows you how to collect trace spans using [Zipkin](http://zipkin.io).
 * Install the required Istio Addon: [Zipkin](http://zipkin.io)
+
   ```bash
-  $ kubectl apply -f install/kubernetes/addons/zipkin.yaml
+  $ kubectl apply -f istio-0.1.6/install/kubernetes/addons/zipkin.yaml
   ```
+
 * Access your **Zipkin Dashboard**. Get the IP of your cluster `kubectl get nodes` and then the NodePort of your Zipkin service `kubectl get svc | grep zipkin` or you can run the following command to output both:
   ```bash
-  $ echo $(kubectl get po -l app=zipkin -o jsonpath={.items[0].status.hostIP}):$(kubectl get svc zipkin -o jsonpath={.spec.ports[0].nodePort})
+  $ ZIPKIN=http://$(kubectl get po -l app=zipkin -o jsonpath='{.items[0].status.hostIP}'):$(kubectl get svc zipkin -o jsonpath='{.spec.ports[0].nodePort}')
+  $ echo $ZIPKIN
   184.xxx.yyy.zzz:30XYZ
   ```  
   Your dashboard should like this:
   ![zipkin](images/zipkin.png)
 
-* Send traffic to that service by refreshing your browser to `http://184.xxx.yyy.zzz:30XYZ/productpage` multiple times. You can also do `curl` on your terminal to that URL in a while loop.
+* Send traffic to that service by refreshing your browser to `http://184.xxx.yyy.zzz:30XYZ/productpage` multiple times. You can also do reuse the `curl` for loop from earlier.
 
 * Go to your Zipkin Dashboard again and you will see a number of traces done. _Click on Find Traces button with the appropriate Start and End Time_
+
 ![zipkin](images/zipkin-traces.png)
+
 * Click on one of those traces and you will see the details of the traffic you sent to your BookInfo App. It shows how much time it took for the request on `productpage` to finish. It also shows how much time it took for the requests on the `details`,`reviews`, and `ratings` services.
+
 ![zipkin](images/zipkin-details.png)
 
 [Zipkin Tracing on Istio](https://istio.io/docs/tasks/zipkin-tracing.html)

--- a/new-metrics-rule.yaml
+++ b/new-metrics-rule.yaml
@@ -1,0 +1,44 @@
+revision: "1"
+rules:
+- aspects:
+  - adapter: prometheus
+    kind: metrics
+    params:
+      metrics:
+      - descriptor_name: response_size
+        value: response.size | 0
+        labels:
+          source: source.labels["app"] | "unknown"
+          target: target.service | "unknown"
+          service: target.labels["app"] | "unknown"
+          version: target.labels["version"] | "unknown"
+          method: request.path | "unknown"
+          response_code: response.code | 200
+  - adapter: default
+    kind: access-logs
+    params:
+      logName: combined_log
+      log:
+        descriptor_name: accesslog.combined
+        template_expressions:
+          originIp: origin.ip
+          sourceUser: origin.user
+          timestamp: request.time
+          method: request.method
+          url: request.path
+          protocol: request.scheme
+          responseCode: response.code
+          responseSize: response.size
+          referer: request.referer
+          userAgent: request.headers["user-agent"]
+        labels:
+          originIp: origin.ip
+          sourceUser: origin.user
+          timestamp: request.time
+          method: request.method
+          url: request.path
+          protocol: request.scheme
+          responseCode: response.code
+          responseSize: response.size
+          referer: request.referer
+          userAgent: request.headers["user-agent"]

--- a/node-port.yaml
+++ b/node-port.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: productpage
+  labels:
+    app: productpage
+spec:
+  type: NodePort
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: productpage


### PR DESCRIPTION
Lots of usability and readability issues founds and resolved.

* added instructions on putting this code and the istio sample in
a well known location to be easier to give instructions for

* put pasted YAML files into this repo so that there's less blocks
of copy/paste involved.